### PR TITLE
Add Heroku easy deploy and Social login optionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,29 +50,9 @@ Enable PostGIS extension on your database via `bundle exec rake db:enable_postgi
 
 Then you can run the migrations with `bundle exec rake db:migrate`
 
-## Config via ENV
+## Configuration
 
-- `BUNDLE_GEMFILE`
-- `DATABASE_URL`
-- `ELASTICSEARCH_URL` : required
-- `FACEBOOK_CLIENT_ID` : optional, for Meta data and Facebook login
-- `FACEBOOK_CLIENT_SECRET` : optional
-- `GA_TRACKING_ID` : optional, Google Analytics
-- `GEONAMES_URL` : optional, for import only
-- `GOOGLE_CLIENT_ID` : optional
-- `GOOGLE_CLIENT_SECRET` : optional
-- `MAILER_HOST`
-- `MAILJET_API_KEY`
-- `MAILJET_API_SECRET`
-- `MYSQL_URL` : optional, for import only
-- `PG_URL` : optional, for import only
-- `RAILS_ENV`
-- `RAILS_LOG_TO_STDOUT`
-- `RAILS_SERVE_STATIC_FILES`
-- `REDIRECT_ALL_TRAFFIC` : optional
-- `SECRET_KEY_BASE` : required
-- `SERVER_NAME` : optional, for redirects only
-- `SLAASK_WIDGET_KEY` : optional, for visitors chat with you
+[Configuration ENV variables](https://github.com/covoiturage-libre/covoiturage-libre/wiki/Configuration-ENV-variables)
 
 ## Static pages
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,29 @@ Then you can run the migrations
 
 `bundle exec rake db:migrate`
 
+## Config via ENV
+
+- `BUNDLE_GEMFILE`
+- `FACEBOOK_CLIENT_ID`
+- `FACEBOOK_CLIENT_SECRET`
+- `GA_TRACKING_ID`
+- `GEONAMES_URL`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `MAILER_HOST`
+- `MAILJET_API_KEY`
+- `MAILJET_API_SECRET`
+- `MYSQL_URL`
+- `omniauth.auth`
+- `PG_URL`
+- `RAILS_ENV`
+- `RAILS_LOG_TO_STDOUT`
+- `RAILS_SERVE_STATIC_FILES`
+- `REDIRECT_ALL_TRAFFIC`
+- `SECRET_KEY_BASE`
+- `SERVER_NAME`
+- `SLAASK_WIDGET_KEY`
+
 ## Static pages
 
 Some static pages are needed, normally created in the built-in CMS. The seedbank gem is used to import them (https://github.com/james2m/seedbank)

--- a/README.md
+++ b/README.md
@@ -45,15 +45,9 @@ NB : a simple postgresql config file does the jobs. The adapter is `postgis` but
 
 * Database initialization
 
-Install postgis extension on your database :
+Enable PostGIS extension on your database via `bundle exec rake db:enable_postgis`.
 
-```
-user=> CREATE extension postgis;
-CREATE EXTENSION
-```
-Then you can run the migrations
-
-`bundle exec rake db:migrate`
+Then you can run the migrations with `bundle exec rake db:migrate`
 
 ## Config via ENV
 
@@ -78,10 +72,6 @@ Then you can run the migrations
 - `SECRET_KEY_BASE` : required
 - `SERVER_NAME` : optional, for redirects only
 - `SLAASK_WIDGET_KEY` : optional, for visitors chat with you
-
-## Enable Postgis on PostgreSQL
-
-`rake db:enable_postgis`
 
 ## Static pages
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Then you can run the migrations
 ## Config via ENV
 
 - `BUNDLE_GEMFILE`
+- `DATABASE_URL`
+- `ELASTICSEARCH_URL`
 - `FACEBOOK_CLIENT_ID`
 - `FACEBOOK_CLIENT_SECRET`
 - `GA_TRACKING_ID`

--- a/README.md
+++ b/README.md
@@ -75,6 +75,10 @@ Then you can run the migrations
 - `SERVER_NAME` : optional, for redirects only
 - `SLAASK_WIDGET_KEY` : optional, for visitors chat with you
 
+## Enable Postgis on PostgreSQL
+
+`rake db:enable_postgis`
+
 ## Static pages
 
 Some static pages are needed, normally created in the built-in CMS. The seedbank gem is used to import them (https://github.com/james2m/seedbank)

--- a/README.md
+++ b/README.md
@@ -55,26 +55,25 @@ Then you can run the migrations
 
 - `BUNDLE_GEMFILE`
 - `DATABASE_URL`
-- `ELASTICSEARCH_URL`
-- `FACEBOOK_CLIENT_ID`
-- `FACEBOOK_CLIENT_SECRET`
-- `GA_TRACKING_ID`
-- `GEONAMES_URL`
-- `GOOGLE_CLIENT_ID`
-- `GOOGLE_CLIENT_SECRET`
+- `ELASTICSEARCH_URL` : required
+- `FACEBOOK_CLIENT_ID` : optional, for Meta data and Facebook login
+- `FACEBOOK_CLIENT_SECRET` : optional
+- `GA_TRACKING_ID` : optional, Google Analytics
+- `GEONAMES_URL` : optional, for import only
+- `GOOGLE_CLIENT_ID` : optional
+- `GOOGLE_CLIENT_SECRET` : optional
 - `MAILER_HOST`
 - `MAILJET_API_KEY`
 - `MAILJET_API_SECRET`
-- `MYSQL_URL`
-- `omniauth.auth`
-- `PG_URL`
+- `MYSQL_URL` : optional, for import only
+- `PG_URL` : optional, for import only
 - `RAILS_ENV`
 - `RAILS_LOG_TO_STDOUT`
 - `RAILS_SERVE_STATIC_FILES`
-- `REDIRECT_ALL_TRAFFIC`
-- `SECRET_KEY_BASE`
-- `SERVER_NAME`
-- `SLAASK_WIDGET_KEY`
+- `REDIRECT_ALL_TRAFFIC` : optional
+- `SECRET_KEY_BASE` : required
+- `SERVER_NAME` : optional, for redirects only
+- `SLAASK_WIDGET_KEY` : optional, for visitors chat with you
 
 ## Static pages
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ CovoiturageLibre is a Carpooling Open Source platform, originally created for th
 
 It aims at providing a free, non-profit carpooling service for the shared economy, with no for-profit company controlling the service.
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/covoiturage-libre/covoiturage-libre)
+
 ## Licence
 
  GNU GENERAL PUBLIC LICENSE v3.0, see LICENCE.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ It aims at providing a free, non-profit carpooling service for the shared econom
 
 You can find the repository for the Android app just [here](https://github.com/serelion/covoiturage-libre-android).
 
-[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/covoiturage-libre/covoiturage-libre)
+[![Deploy on Heroku](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy?template=https://github.com/covoiturage-libre/covoiturage-libre)
+[![Deploy on Scalingo](https://cdn.scalingo.com/deploy/button.svg)](https://my.scalingo.com/deploy?source=https://github.com/covoiturage-libre/covoiturage-libre)
 
 ## Licence
 

--- a/app.json
+++ b/app.json
@@ -12,7 +12,52 @@
   "env": {
     "SECRET_KEY_BASE": {
       "description": "A secret key for verifying the integrity of signed cookies.",
-      "generator": "secret"
+      "generator": "secret",
+      "required": true
+    },
+    "MAILER_HOST": {
+      "description": "Host for URL in mails.",
+      "required": true
+    },
+    "MAILER_HOST": {
+      "description": "Host for URL in mails.",
+      "required": true
+    },
+    "MAILJET_API_KEY": {
+      "description": "For mails.",
+      "required": true
+    },
+    "MAILJET_API_SECRET": {
+      "description": "For mails.",
+      "required": true
+    },
+    "FACEBOOK_CLIENT_ID": {
+      "description": "For Meta data and Facebook login.",
+      "required": false
+    },
+    "FACEBOOK_CLIENT_SECRET": {
+      "description": "For Facebook login.",
+      "required": false
+    },
+    "GOOGLE_CLIENT_ID": {
+      "description": "For Google login.",
+      "required": false
+    },
+    "GOOGLE_CLIENT_SECRET": {
+      "description": "For Google login.",
+      "required": false
+    },
+    "GEONAMES_URL": {
+      "description": "For import only",
+      "required": false
+    },
+    "GA_TRACKING_ID": {
+      "description": "Google Analytics",
+      "required": false
+    },
+    "SLAASK_WIDGET_KEY": {
+      "description": "For visitors chat with you.",
+      "required": false
     }
   },
   "scripts": {

--- a/app.json
+++ b/app.json
@@ -16,6 +16,6 @@
     }
   },
   "scripts": {
-    "postdeploy": "rake db:enable_postgis db:migrate db:seed:pages"
+    "postdeploy": "rake db:enable_postgis db:migrate db:seed:pages searchkick:reindex CLASS=City"
   }
 }

--- a/app.json
+++ b/app.json
@@ -1,0 +1,21 @@
+{
+  "name": "CovoiturageLibre",
+  "description": "CovoiturageLibre is a Carpooling Open Source platform",
+  "website": "https://covoiturage-libre.fr/",
+  "repository": "https://github.com/covoiturage-libre/covoiturage-libre",
+  "image": "heroku/ruby",
+  "addons": [
+    "heroku-postgresql:hobby-dev",
+    "heroku-redis:hobby-dev",
+    "searchbox:starter"
+  ],
+  "env": {
+    "SECRET_KEY_BASE": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    }
+  },
+  "scripts": {
+    "postdeploy": "rake db:enable_postgis db:migrate db:seed:pages"
+  }
+}

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -6,14 +6,16 @@
       = link_to "S'inscrire", new_user_registration_path
 
     .well
-      = link_to omniauth_authorize_path(resource_name, :facebook), class: "btn-lg btn-primary btn-block" do
-        .sso-icon= icon('facebook')
-        .sso-label Connexion via Facebook
-        .clearfix
-      = link_to omniauth_authorize_path(resource_name, :google_oauth2), class: "btn-lg btn-danger btn-block" do
-        .sso-icon= icon('google')
-        .sso-label Connexion via Google
-        .clearfix
+      - if Devise.omniauth_configs.has_key?(:facebook)
+        = link_to omniauth_authorize_path(resource_name, :facebook), class: "btn-lg btn-primary btn-block" do
+          .sso-icon= icon('facebook')
+          .sso-label Connexion via Facebook
+          .clearfix
+      - if Devise.omniauth_configs.has_key?(:google_oauth2)
+        = link_to omniauth_authorize_path(resource_name, :google_oauth2), class: "btn-lg btn-danger btn-block" do
+          .sso-icon= icon('google')
+          .sso-label Connexion via Google
+          .clearfix
 
     .well
       %center

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,8 +21,10 @@
     %meta{property: 'og:site_name',    content: 'Covoiturage-libre.fr'}
     %meta{property: 'og:image',        content: @meta[:image_url]}
     %meta{property: 'og:url',          content: @meta[:url]}
-    / facebook app id
-    %meta{property: 'fb:app_id',       content: ENV['FACEBOOK_CLIENT_ID']}
+
+    - if ENV['FACEBOOK_CLIENT_ID']
+      / facebook app id
+      %meta{property: 'fb:app_id',       content: ENV['FACEBOOK_CLIENT_ID']}
 
     / Twitter Card data
     %meta{name: 'twitter:title',       content: @meta[:title]}

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -248,8 +248,12 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
   # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
-  config.omniauth :facebook, ENV["FACEBOOK_CLIENT_ID"], ENV["FACEBOOK_CLIENT_SECRET"], provider_ignores_state: true
-  config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], { access_type: "offline", approval_prompt: "" }
+  if ENV["FACEBOOK_CLIENT_ID"].present? && ENV["FACEBOOK_CLIENT_SECRET"].present?
+    config.omniauth :facebook, ENV["FACEBOOK_CLIENT_ID"], ENV["FACEBOOK_CLIENT_SECRET"], provider_ignores_state: true
+  end
+  if ENV["GOOGLE_CLIENT_ID"].present?
+    config.omniauth :google_oauth2, ENV["GOOGLE_CLIENT_ID"], ENV["GOOGLE_CLIENT_SECRET"], { access_type: "offline", approval_prompt: "" }
+  end
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -1,0 +1,6 @@
+namespace :db do
+  desc "Enable PostGIS"
+  task enable_postgis: :environment do
+    ActiveRecord::Base.connection.execute('CREATE EXTENSION postgis;')
+  end
+end

--- a/scalingo.json
+++ b/scalingo.json
@@ -1,0 +1,53 @@
+{
+  "name": "CovoiturageLibre",
+  "description": "CovoiturageLibre is a Carpooling Open Source platform",
+  "website": "https://covoiturage-libre.fr/",
+  "repository": "https://github.com/covoiturage-libre/covoiturage-libre",
+  "addons": [
+    "scalingo-postgresql",
+    "scalingo-redis",
+    "scalingo-elasticsearch"
+  ],
+  "env": {
+    "SECRET_KEY_BASE": {
+      "description": "A secret key for verifying the integrity of signed cookies.",
+      "generator": "secret"
+    },
+    "MAILER_HOST": {
+      "description": "Host for URL in mails. Required."
+    },
+    "MAILER_HOST": {
+      "description": "Host for URL in mails. Required."
+    },
+    "MAILJET_API_KEY": {
+      "description": "For mails. Required."
+    },
+    "MAILJET_API_SECRET": {
+      "description": "For mails. Required."
+    },
+    "FACEBOOK_CLIENT_ID": {
+      "description": "For Meta data and Facebook login."
+    },
+    "FACEBOOK_CLIENT_SECRET": {
+      "description": "For Facebook login."
+    },
+    "GOOGLE_CLIENT_ID": {
+      "description": "For Google login."
+    },
+    "GOOGLE_CLIENT_SECRET": {
+      "description": "For Google login."
+    },
+    "GEONAMES_URL": {
+      "description": "For import only"
+    },
+    "GA_TRACKING_ID": {
+      "description": "Google Analytics"
+    },
+    "SLAASK_WIDGET_KEY": {
+      "description": "For visitors chat with you."
+    }
+  },
+  "scripts": {
+    "postdeploy": "rake db:enable_postgis db:migrate db:seed:pages searchkick:reindex CLASS=City"
+  }
+}


### PR DESCRIPTION
To allow project to be easily reusable by others.

- ENV Settings list in `README.md`
- Social login as optional according to presence of ENV `FACEBOOK_CLIENT_ID` and/or `GOOGLE_CLIENT_ID` for each, test by toggling each one

- Heroku one-click free deploy with addons via `app.json` to be able to reuse the platform for own purpose or test
    Test : https://heroku.com/deploy?template=https://github.com/nicolasleger/covoiturage-libre/tree/add_heroku_easy_deploy
Live demo : https://covoiturage-libre.herokuapp.com

- Scalingo one-click deploy with addons via `scalingo.json` to be able to reuse the platform for own purpose or test
    Test : https://my.scalingo.com/deploy?source=https://github.com/nicolasleger/covoiturage-libre#add_heroku_easy_deploy