### PR TITLE
city selection with jquery autofocus

### DIFF
--- a/app/assets/javascripts/_init-autocomplete.js
+++ b/app/assets/javascripts/_init-autocomplete.js
@@ -31,7 +31,9 @@ jQuery.fn.extend({
             .append("<div><b>" + item.city + "</b><br />" + item.city + ', ' + item.country + ', ' + item.postcode + "</div>")
             .appendTo(ul);
         }
-      }
+      },
+      // automatically select first item from autocomplete menu
+      autoFocus: true
     }).blur(function () {
       if ($(this).val() == "") {
         $(this).parent().next(2).find("input").val('');


### PR DESCRIPTION
I think this fixes issue #130, which was pretty bad : 
  - searching for unrecognized cities - this leads to blank result page! -
  - requiring a click on the proposition menu

now the first matching city name is automatically selected unless the user clicks on another !
Thanks jQuery !