### PR TITLE
show steps price in announce

### DIFF
--- a/app/assets/stylesheets/_trip.scss
+++ b/app/assets/stylesheets/_trip.scss
@@ -78,3 +78,18 @@ a.trip-item:hover {
     font-size: 12px;
   }
 }
+
+.small_price {
+  color: $priceColor;
+  font-weight: bold;
+}
+
+.main_seats {
+  display: block;
+  float: left;
+  padding: 8px;
+  text-align: center;
+  color: $priceColor;
+  font-size: 24px;
+  font-weight: bold;
+}

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -80,7 +80,7 @@
                     = link_to 'Afficher le numéro de téléphone', trip_phone_path(@trip), class: 'btn btn-warning', remote: true, disable_with: 'En attente...'
           .col-md-4
             .main_seats
-              = "#{@trip.seats} places"
+              = "#{@trip.seats} place#{'s' if @trip.seats > 1}"
         .row
           .col-md-9.col-md-offset-1
             %br

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -5,30 +5,33 @@
 
 .page-header
   %h1
-    ="Voyage de #{@trip.point_from.city} à #{@trip.point_to.city}"
-    %small
-      = distance_of_time_in_words(@trip.total_time) if @trip.total_time.present?
-      = "- #{(@trip.total_distance / 1000).round} km" if @trip.total_distance.present?
+    ="Voyage de #{@trip.point_from.city} à #{@trip.point_to.city} le #{l @trip.departure_date}"
 
 .row
   .col-md-6
     .panel.panel-default
       .panel-body
         .row
-          .col-lg-4
+          .col-md-4
             Départ
-          .col-lg-8
+          .col-md-8
             %strong= @trip.point_from.city
+        - @trip.step_points.each do |point|
+          .row
+            .col-md-4
+              Étape
+            .col-md-4
+              %strong= point.city
+            .col-md-4
+              .small_price= number_to_currency point.price
         .row
           .col-md-4
             Arrivée
-          .col-md-8
-            %strong= @trip.point_to.city
-        .row
           .col-md-4
-            Date de départ
-          .col-md-8
-            %strong=l @trip.departure_date
+            %strong= @trip.point_to.city
+          .col-md-4
+            .small_price= number_to_currency @trip.price
+        %hr
         .row
           .col-md-4
             Heure de départ
@@ -36,24 +39,21 @@
             %strong=l @trip.departure_time, format: :short
         .row
           .col-md-4
-            Nombre de places
-          .col-md-8
-            %strong=@trip.seats
-        .row
-          .col-md-4
             =t Trip.human_attribute_name(:comfort)
           .col-md-8
             %strong=t :"activerecord.attributes.trip.comfort_#{@trip.comfort}"
         .row
           .col-md-4
-            Prix
-          .col-md-8
-            = number_to_currency @trip.price
-        .row
-          .col-md-4
             Fumeur
           .col-md-8
             =t :"activerecord.attributes.trip.smoking_#{@trip.smoking}"
+        .row
+          .col-md-4
+            Estimations
+          .col-md-8
+            %strong
+              = distance_of_time_in_words(@trip.total_time) if @trip.total_time.present?
+              = "- #{(@trip.total_distance / 1000).round} km" if @trip.total_distance.present?
 
     .panel.panel-default
       .panel-heading
@@ -79,10 +79,8 @@
                   - if @trip.phone.present?
                     = link_to 'Afficher le numéro de téléphone', trip_phone_path(@trip), class: 'btn btn-warning', remote: true, disable_with: 'En attente...'
           .col-md-4
-            .price
-              %p= "#{@trip.price} €"
-              .seats
-                = "#{@trip.seats} places"
+            .main_seats
+              = "#{@trip.seats} places"
         .row
           .col-md-9.col-md-offset-1
             %br


### PR DESCRIPTION
This is my solution for #140.
The new layout puts emphasis on the main trip, the date and the seats:

![covoli0](https://cloud.githubusercontent.com/assets/540760/25505441/f61cdf20-2ba1-11e7-95c7-df0807c1e9be.png)

Prices are all aligned and clearly visible.
