### PR TITLE
fix carousel slides erroneously updated in most pages

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -27,23 +27,26 @@
 //= require turbolinks
 //= require ga
 
-$(document).on('turbolinks:load', function() {
+$(document).on("turbolinks:load", function() {
   var activeStickerIndex = 0;
-  var stickersLength = $('.c-stickers-carousel__item').length;
+  var stickersLength = $(".c-stickers-carousel__item").length;
 
   function showActiveCarousel() {
-    $('.c-stickers-carousel__item').hide();
-    var index = (activeStickerIndex % stickersLength) + 1;
-    $('.c-stickers-carousel__item:nth-child(' + index + ')').show();
-    $('#active-sticker').html(index);
+    // Try to show carousel only if it's present in page
+    if ($(".c-stickers-carousel__item").length > 0) {
+      $(".c-stickers-carousel__item").hide();
+      var index = (activeStickerIndex % stickersLength) + 1;
+      $(".c-stickers-carousel__item:nth-child(" + index + ")").show();
+      $("#active-sticker").html(index);
+    }
   }
 
-  $('.js-carousel-left').on('click', function() {
+  $(".js-carousel-left").on("click", function() {
     activeStickerIndex = activeStickerIndex > 0 ? activeStickerIndex - 1 : stickersLength - 1;
     showActiveCarousel();
   });
 
-  $('.js-carousel-right').on('click', function() {
+  $(".js-carousel-right").on("click", function() {
     activeStickerIndex += 1;
     showActiveCarousel();
   });


### PR DESCRIPTION
Currently, all the site's pages except the homepage try to show the carousel slides and spawn an error in the javascript console.
This fixes the js error by adding a check for the carousel presence.

(plus the usual js cleaning :)