### PR TITLE
Fix/double results in search 139

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,7 @@ rvm:
 env:
   - DATABASE_URL=postgres://postgres@localhost/postgres
 before_script:
-  - bundle exec rake db:enable_postgis
-  - bin/rails db:migrate RAILS_ENV=test
+  - RAILS_ENV=test bundle exec rake db:enable_postgis db:migrate db:seed:pages searchkick:reindex CLASS=City 
 cache: bundler
 services:
   - elasticsearch

--- a/app/models/geoname.rb
+++ b/app/models/geoname.rb
@@ -1,4 +1,3 @@
 class Geoname < ApplicationRecord
   searchkick word_start: [:place_name]
-
 end

--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -42,12 +42,16 @@ class Trip < ApplicationRecord
   default_scope { includes(:points).order('created_at ASC') }
 
   scope :from_to, -> (from_lon, from_lat, to_lon, to_lat) {
-    select('trips.*,
+    # Avoid Trips doublon
+    matching_points = Point.select("DISTINCT ON (point_a.trip_id) point_a.*,
       point_a.id as point_a_id, point_a.price as point_a_price,
       point_b.id as point_b_id, point_b.price as point_b_price,
-      trips.id'). # trips.id is necessary here for the COUNT_COLUMN method used by Kaminari counting.
-    joins('INNER JOIN points AS point_a ON trips.id = point_a.trip_id').
-    joins('INNER JOIN points AS point_b ON trips.id = point_b.trip_id').
+      ST_Distance(
+        ST_GeographyFromText('SRID=4326;POINT(' || point_a.lon || ' ' || point_a.lat || ')'),
+        ST_GeographyFromText('SRID=4326;POINT(' || point_b.lon || ' ' || point_b.lat || ')')
+      ) AS point_distance").
+    from('points AS point_a').
+    joins('INNER JOIN points AS point_b ON point_b.trip_id = point_a.trip_id').
     where("ST_Dwithin(
            ST_GeographyFromText('SRID=4326;POINT(' || point_a.lon || ' ' || point_a.lat || ')'),
            ST_GeographyFromText('SRID=4326;POINT(? ?)'),
@@ -56,31 +60,60 @@ class Trip < ApplicationRecord
            ST_GeographyFromText('SRID=4326;POINT(' || point_b.lon || ' ' || point_b.lat || ')'),
            ST_GeographyFromText('SRID=4326;POINT(? ?)'),
            #{SEARCH_DISTANCE_IN_METERS})", to_lon.to_f, to_lat.to_f).
-    where('point_a.rank < point_b.rank')
+    where('point_a.rank < point_b.rank').
+    order('point_a.trip_id ASC, point_distance ASC')
+
+    select('trips.*,
+      point_a_id, point_a_price,
+      point_b_id, point_b_price,
+      trips.id'). # trips.id is necessary here for the COUNT_COLUMN method used by Kaminari counting.
+    joins("INNER JOIN (#{matching_points.to_sql}) AS point_a ON trips.id = point_a.trip_id")
   }
 
   scope :from_only, -> (from_lon, from_lat) {
+    # Avoid Trips doublon
+    matching_points = Point.select("DISTINCT ON (point_a.trip_id) point_a.*,
+      point_a.id AS point_a_id, point_a.price AS point_a_price,
+      ST_Distance(
+        ST_GeographyFromText('SRID=4326;POINT(' || point_a.lon || ' ' || point_a.lat || ')'),
+        ST_GeographyFromText('SRID=4326;POINT(#{from_lon.to_f} #{from_lat.to_f})')
+      ) AS point_a_distance")
+    .from('points AS point_a')
+    .where("ST_Dwithin(
+      ST_GeographyFromText('SRID=4326;POINT(' || point_a.lon || ' ' || point_a.lat || ')'),
+      ST_GeographyFromText('SRID=4326;POINT(? ?)'),
+      #{SEARCH_DISTANCE_IN_METERS}
+    )", from_lon.to_f, from_lat.to_f)
+    .where("point_a.kind <> 'To'")
+    .order('point_a.trip_id ASC, point_a_distance ASC')
+
     select('trips.*,
-      point_a.id as point_a_id, point_a.price as point_a_price,
+      point_a_id, point_a_price, point_a_distance,
       trips.id'). # trips.id is necessary here for the COUNT_COLUMN method used by Kaminari counting.
-    joins('INNER JOIN points AS point_a ON trips.id = point_a.trip_id').
-    where("ST_Dwithin(
-           ST_GeographyFromText('SRID=4326;POINT(' || point_a.lon || ' ' || point_a.lat || ')'),
-           ST_GeographyFromText('SRID=4326;POINT(? ?)'),
-           #{SEARCH_DISTANCE_IN_METERS})", from_lon.to_f, from_lat.to_f).
-    where("point_a.kind <> 'To'")
+    joins("INNER JOIN (#{matching_points.to_sql}) AS point_a ON trips.id = point_a.trip_id")
   }
 
   scope :to_only, -> (to_lon, to_lat) {
+    # Avoid Trips doublon
+    matching_points = Point.select("DISTINCT ON (point_b.trip_id) point_b.*,
+      point_b.id AS point_b_id, point_b.price AS point_b_price,
+      ST_Distance(
+        ST_GeographyFromText('SRID=4326;POINT(' || point_b.lon || ' ' || point_b.lat || ')'),
+        ST_GeographyFromText('SRID=4326;POINT(#{to_lon.to_f} #{to_lat.to_f})')
+      ) AS point_b_distance")
+    .from('points AS point_b')
+    .where("ST_Dwithin(
+      ST_GeographyFromText('SRID=4326;POINT(' || point_b.lon || ' ' || point_b.lat || ')'),
+      ST_GeographyFromText('SRID=4326;POINT(? ?)'),
+      #{SEARCH_DISTANCE_IN_METERS}
+    )", to_lon.to_f, to_lat.to_f)
+    .where("point_b.kind <> 'From'")
+    .order('point_b.trip_id ASC, point_b_distance ASC')
+
     select('trips.*,
-      point_b.id as point_b_id, point_b.price as point_b_price,
+      point_b_id, point_b_price, point_b_distance,
       trips.id'). # trips.id is necessary here for the COUNT_COLUMN method used by Kaminari counting.
-    joins('INNER JOIN points AS point_b ON trips.id = point_b.trip_id').
-    where("ST_Dwithin(
-           ST_GeographyFromText('SRID=4326;POINT(' || point_b.lon || ' ' || point_b.lat || ')'),
-           ST_GeographyFromText('SRID=4326;POINT(? ?)'),
-           #{SEARCH_DISTANCE_IN_METERS})", to_lon.to_f, to_lat.to_f).
-    where("point_b.kind <> 'From'")
+    joins("INNER JOIN (#{matching_points.to_sql}) AS point_b ON trips.id = point_b.trip_id")
   }
 
   def to_param

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -2,11 +2,11 @@ require 'rails_helper'
 
 describe Trip, type: :model do
 
-  before(:all) do
+  before(:each) do
     city = City.create!
 
     @trip = Trip.create!(
-      departure_date: Date.today,
+      departure_date: Time.zone.today,
       departure_time: Time.now,
       price: 12,
       title: 'M',

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -39,10 +39,10 @@ describe Trip, type: :model do
       }).to eq [{
         'id' => @trip.id,
         'price' => @trip.price,
-        'point_a_id' => @trip.points[1].id,
-        'point_a_price' => @trip.points[1].price,
-        'point_b_id' => @trip.points[2].id,
-        'point_b_price' => @trip.points[2].price
+        'point_a_id' => @trip.points[0].id,
+        'point_a_price' => @trip.points[0].price,
+        'point_b_id' => @trip.points[1].id,
+        'point_b_price' => @trip.points[1].price
       }]
     end
   end

--- a/spec/models/trip_spec.rb
+++ b/spec/models/trip_spec.rb
@@ -1,0 +1,93 @@
+require 'rails_helper'
+
+describe Trip, type: :model do
+
+  before(:all) do
+    city = City.create!
+
+    @trip = Trip.create!(
+      departure_date: Date.today,
+      departure_time: Time.now,
+      price: 12,
+      title: 'M',
+      name: 'John',
+      email: 'yolo@example.com',
+      seats: 2,
+      comfort: 'comfort',
+
+      points: [
+        Point.new(kind: 'From', lat: 1.23, lon: 1.24, city: city),
+        Point.new(kind: 'Step', lat: 1.24, lon: 1.25, city: city, rank: 1, price: 4),
+        Point.new(kind: 'Step', lat: 1.25, lon: 1.26, city: city, rank: 2, price: 5),
+        Point.new(kind: 'To', lat: 1.83, lon: 1.84, city: city)
+      ]
+    )
+  end
+
+  describe '.from_to' do
+    it "should return each matching Trip only one time and with the nearest points" do
+      results = Trip.from_to(1.24, 1.23, 1.25, 1.24)
+                    .where(id: @trip.id)
+
+      expect(results).to be_a ActiveRecord::Relation
+      expect(results.map { |result|
+        result.attributes.slice(
+          'id', 'price',
+          'point_a_id', 'point_a_price',
+          'point_b_id', 'point_b_price'
+        )
+      }).to eq [{
+        'id' => @trip.id,
+        'price' => @trip.price,
+        'point_a_id' => @trip.points[1].id,
+        'point_a_price' => @trip.points[1].price,
+        'point_b_id' => @trip.points[2].id,
+        'point_b_price' => @trip.points[2].price
+      }]
+    end
+  end
+
+  describe '.from_only' do
+    # TODO: only one time and with the nearest from point
+    it "should return each matching Trip multiple time with different from point" do
+      results = Trip.from_only(1.25, 1.24)
+                    .where(id: @trip.id)
+
+      expect(results).to be_a ActiveRecord::Relation
+      expect(results.map { |result|
+        result.attributes.slice(
+          'id', 'price',
+          'point_a_id', 'point_a_price'
+        )
+      }).to eq [{
+        'id' => @trip.id,
+        'price' => @trip.price,
+        'point_a_id' => @trip.points[1].id,
+        'point_a_price' => @trip.points[1].price
+      }]
+    end
+  end
+
+  describe '.to_only' do
+    it "should return each matching Trip only one time with different to point" do
+      results = Trip.to_only(1.26, 1.25)
+                    .where(id: @trip.id)
+
+      puts results.map(&:to_json)
+      puts results.map(&:attributes)
+      expect(results).to be_a ActiveRecord::Relation
+      expect(results.map { |result|
+        result.attributes.slice(
+          'id', 'price',
+          'point_b_id', 'point_b_price'
+        )
+      }).to eq [{
+        'id' => @trip.id,
+        'price' => @trip.price,
+        'point_b_id' => @trip.points[2].id,
+        'point_b_price' => @trip.points[2].price
+      }]
+    end
+  end
+
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 describe User, type: :model do
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,8 +35,8 @@ RSpec.configure do |config|
   config.order = "random"
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :transaction
-    DatabaseCleaner.clean_with(:truncation)
+    DatabaseCleaner.strategy = :deletion, { except: %w[spatial_ref_sys] }
+    DatabaseCleaner.clean_with :truncation, { except: %w[spatial_ref_sys] }
     Rails.application.load_seed # loading seeds
   end
 
@@ -45,8 +45,7 @@ RSpec.configure do |config|
   end
 
   config.after(:each) do
-    DatabaseCleaner.clean
-#    drop_schemas
+    DatabaseCleaner.clean # drop_schemas
     Capybara.app_host = 'http://example.com'
     reset_mailer
   end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -35,12 +35,12 @@ RSpec.configure do |config|
   config.order = "random"
 
   config.before(:suite) do
-    DatabaseCleaner.strategy = :deletion, { except: %w[spatial_ref_sys] }
-    DatabaseCleaner.clean_with :truncation, { except: %w[spatial_ref_sys] }
     Rails.application.load_seed # loading seeds
   end
 
   config.before(:each) do
+    DatabaseCleaner.strategy = :deletion, { except: %w[spatial_ref_sys] }
+    DatabaseCleaner.clean_with :truncation, { except: %w[spatial_ref_sys] }
     DatabaseCleaner.start
   end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -13,6 +13,9 @@ Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 ActiveRecord::Migration.maintain_test_schema!
 
+DatabaseCleaner.strategy = :deletion, { except: ['spatial_ref_sys'] }
+DatabaseCleaner.clean_with :truncation, { except: ['spatial_ref_sys'] }
+
 Capybara.app_host = 'http://example.com'
 
 Rails.application.routes.default_url_options[:host] = 'www.example.com'
@@ -34,18 +37,22 @@ RSpec.configure do |config|
 
   config.order = "random"
 
-  config.before(:suite) do
-    Rails.application.load_seed # loading seeds
-  end
-
   config.before(:each) do
-    DatabaseCleaner.strategy = :deletion, { except: %w[spatial_ref_sys] }
-    DatabaseCleaner.clean_with :truncation, { except: %w[spatial_ref_sys] }
     DatabaseCleaner.start
   end
 
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :deletion, { except: ['spatial_ref_sys'] }
+    DatabaseCleaner.clean_with :truncation, { except: ['spatial_ref_sys'] }
+
+    Rails.application.load_seed # loading seeds
+  end
+
   config.after(:each) do
-    DatabaseCleaner.clean # drop_schemas
+    DatabaseCleaner.clean
+  end
+
+  config.after(:all) do
     Capybara.app_host = 'http://example.com'
     reset_mailer
   end


### PR DESCRIPTION
### What does/resolve this PR?

Trajet s'affichant deux fois dans une recherche

### How to deploy this PR by yourself to test it?

Testable sur https://cl-139.herokuapp.com/
Exemple https://cl-139.herokuapp.com/recherche?utf8=%E2%9C%93&search%5Bfrom_city%5D=Paris&search%5Bfrom_lon%5D=2.333333&search%5Bfrom_lat%5D=48.866667&search%5Bto_city%5D=Bordeaux&search%5Bto_lon%5D=-0.566667&search%5Bto_lat%5D=44.833333&search%5Bdate%5D=&commit=Partez+%21

`bundle exec rspec spec/models/trip_spec.rb`

### Issues resolved by this PR

https://github.com/covoiturage-libre/covoiturage-libre/issues/139
