### PR TITLE
Force autoselect city when loosing focus

### DIFF
--- a/app/assets/javascripts/_init-autocomplete.js
+++ b/app/assets/javascripts/_init-autocomplete.js
@@ -2,6 +2,8 @@ jQuery.fn.extend({
   geonameAutocomplete: function () {
     return this.autocomplete({
       minLength: 2,
+      // automatically focus first item from autocomplete menu
+      autoFocus: true,
       source: function (request, response) {
         $.getJSON("/cities/autocomplete?term=" + request.term, function (data) {
           response($.map(data, function (el) {
@@ -15,7 +17,7 @@ jQuery.fn.extend({
             }
           }))
         });
-    },
+      },
       select: function (event, ui) {
         // by default the change event is not triggered on hidden input fields
         // we need it to update the map instantly
@@ -32,11 +34,23 @@ jQuery.fn.extend({
             .appendTo(ul);
         }
       },
-      // automatically select first item from autocomplete menu
-      autoFocus: true
+      focus: function (event, ui) {
+        // memorize latest focused item for selection upon focusout
+        this.latest_focus = ui.item;
+      }
     }).blur(function () {
       if ($(this).val() == "") {
         $(this).parent().next(2).find("input").val('');
+      }
+      // populate with last focused element if different from current
+      // ie force autocomplete
+      if (typeof this.latest_focus !== 'undefined'
+      && this.latest_focus.value != this.value) {
+        this.value = this.latest_focus.value;
+        var lat = $('#' + this.id.replace(/city/, 'lat'));
+        var lon = $('#' + this.id.replace(/city/, 'lon'));
+        lat.val(this.latest_focus.lat).trigger('change');
+        lon.val(this.latest_focus.lon).trigger('change');
       }
     });
   }

--- a/app/assets/javascripts/_init-autocomplete.js
+++ b/app/assets/javascripts/_init-autocomplete.js
@@ -4,7 +4,7 @@ jQuery.fn.extend({
       minLength: 2,
       // automatically focus first item from autocomplete menu
       autoFocus: true,
-      source: function (request, response) {
+      source(request, response) {
         $.getJSON("/cities/autocomplete?term=" + request.term, function (data) {
           response($.map(data, function (el) {
             return {
@@ -18,7 +18,7 @@ jQuery.fn.extend({
           }));
         });
       },
-      select: function (event, ui) {
+      select(event, ui) {
         // by default the change event is not triggered on hidden input fields
         // we need it to update the map instantly
         $("#" + this.id.replace(/city/, "lat")).val(ui.item.lat).trigger("change");
@@ -27,14 +27,14 @@ jQuery.fn.extend({
           ga("send", "event", "Ville", "select", ui.item.city );
         }
       },
-      create: function () {
+      create() {
         $(this).data("ui-autocomplete")._renderItem = function (ul, item) {
           return $("<li>")
             .append("<div><b>" + item.city + "</b><br />" + item.city + ", " + item.country + ", " + item.postcode + "</div>")
             .appendTo(ul);
         }
       },
-      focus: function (event, ui) {
+      focus(event, ui) {
         // memorize latest focused item for selection upon focusout
         this.latestFocus = ui.item;
       }

--- a/app/assets/javascripts/_init-autocomplete.js
+++ b/app/assets/javascripts/_init-autocomplete.js
@@ -14,44 +14,47 @@ jQuery.fn.extend({
               country: el.country,
               lat: el.lat,
               lon: el.lon
-            }
-          }))
+            };
+          }));
         });
       },
       select: function (event, ui) {
         // by default the change event is not triggered on hidden input fields
         // we need it to update the map instantly
-        $('#' + this.id.replace(/city/, 'lat')).val(ui.item.lat).trigger('change');
-        $('#' + this.id.replace(/city/, 'lon')).val(ui.item.lon).trigger('change');
+        $("#" + this.id.replace(/city/, "lat")).val(ui.item.lat).trigger("change");
+        $("#" + this.id.replace(/city/, "lon")).val(ui.item.lon).trigger("change");
         if (typeof ga === "function") {
-          ga('send', 'event', 'Ville', 'select', ui.item.city );
+          ga("send", "event", "Ville", "select", ui.item.city );
         }
       },
       create: function () {
-        $(this).data('ui-autocomplete')._renderItem = function (ul, item) {
+        $(this).data("ui-autocomplete")._renderItem = function (ul, item) {
           return $("<li>")
-            .append("<div><b>" + item.city + "</b><br />" + item.city + ', ' + item.country + ', ' + item.postcode + "</div>")
+            .append("<div><b>" + item.city + "</b><br />" + item.city + ", " + item.country + ", " + item.postcode + "</div>")
             .appendTo(ul);
         }
       },
       focus: function (event, ui) {
         // memorize latest focused item for selection upon focusout
-        this.latest_focus = ui.item;
+        this.latestFocus = ui.item;
       }
     }).blur(function () {
-      if ($(this).val() == "") {
-        $(this).parent().next(2).find("input").val('');
+      if ($(this).val() === "") {
+        $(this).parent().next(2).find("input").val("");
       }
       // populate with last focused element if different from current
       // ie force autocomplete
-      if (typeof this.latest_focus !== 'undefined'
-      && this.latest_focus.value != this.value) {
-        this.value = this.latest_focus.value;
-        var lat = $('#' + this.id.replace(/city/, 'lat'));
-        var lon = $('#' + this.id.replace(/city/, 'lon'));
-        lat.val(this.latest_focus.lat).trigger('change');
-        lon.val(this.latest_focus.lon).trigger('change');
+      if (typeof this.latestFocus !== "undefined"
+      && this.latestFocus.value !== this.value) {
+        this.value = this.latestFocus.value;
+        var lat = $("#" + this.id.replace(/city/, "lat"));
+        var lon = $("#" + this.id.replace(/city/, "lon"));
+        lat.val(this.latestFocus.lat).trigger("change");
+        lon.val(this.latestFocus.lon).trigger("change");
       }
+    }).focus(function () {
+      // reopen completion menu on focus
+      $(this).data("ui-autocomplete").search($(this).val());
     });
   }
 });

--- a/app/views/search/_form.html.haml
+++ b/app/views/search/_form.html.haml
@@ -16,7 +16,7 @@
 
 - content_for :javascript_footer do
   :javascript
-    $('.geoname').geonameAutocomplete();    
+    $('.geoname').geonameAutocomplete();
     $('.datepicker').datepicker({
       dateFormat: "dd/mm/yy",
       minDate: 0

--- a/app/views/search/_form.html.haml
+++ b/app/views/search/_form.html.haml
@@ -16,12 +16,11 @@
 
 - content_for :javascript_footer do
   :javascript
+    $('.geoname').geonameAutocomplete();    
     $('.datepicker').datepicker({
       dateFormat: "dd/mm/yy",
       minDate: 0
     });
-    var geo = $('.geoname')
-    geo.geonameAutocomplete();    
     $('.btn-search-inverse-cities').click(function() {
       ['city', 'lon', 'lat'].forEach(function(fieldName) {
         var $fromInput = $('#search_from_' + fieldName);

--- a/app/views/search/_form.html.haml
+++ b/app/views/search/_form.html.haml
@@ -21,24 +21,7 @@
       minDate: 0
     });
     var geo = $('.geoname')
-    geo.geonameAutocomplete();
-    // force autoselect
-    //~ geo.click(function() {
-      //~ console.log('click');
-     //~ $(this).autocomplete('search', $(this).val());
-    //~ });
-    //~ geo.focusout(function() {
-      //~ console.log('focus out');
-      //~ window.globalgeo = $(this);
-      //~ $(this).autocomplete('search', $(this).val());
-      //~ $(this).data('ui-autocomplete')._trigger('selectFirst');
-    //~ });
-    //~ geo.on('click focus', function() {
-      //~ console.log('clickfocus');
-      //~ $('#search_from_lon').val('');
-      //~ $('#search_from_lat').val('');
-    //~ });
-    
+    geo.geonameAutocomplete();    
     $('.btn-search-inverse-cities').click(function() {
       ['city', 'lon', 'lat'].forEach(function(fieldName) {
         var $fromInput = $('#search_from_' + fieldName);

--- a/app/views/search/_form.html.haml
+++ b/app/views/search/_form.html.haml
@@ -16,11 +16,29 @@
 
 - content_for :javascript_footer do
   :javascript
-    $('.geoname').geonameAutocomplete();
     $('.datepicker').datepicker({
       dateFormat: "dd/mm/yy",
       minDate: 0
     });
+    var geo = $('.geoname')
+    geo.geonameAutocomplete();
+    // force autoselect
+    //~ geo.click(function() {
+      //~ console.log('click');
+     //~ $(this).autocomplete('search', $(this).val());
+    //~ });
+    //~ geo.focusout(function() {
+      //~ console.log('focus out');
+      //~ window.globalgeo = $(this);
+      //~ $(this).autocomplete('search', $(this).val());
+      //~ $(this).data('ui-autocomplete')._trigger('selectFirst');
+    //~ });
+    //~ geo.on('click focus', function() {
+      //~ console.log('clickfocus');
+      //~ $('#search_from_lon').val('');
+      //~ $('#search_from_lat').val('');
+    //~ });
+    
     $('.btn-search-inverse-cities').click(function() {
       ['city', 'lon', 'lat'].forEach(function(fieldName) {
         var $fromInput = $('#search_from_' + fieldName);


### PR DESCRIPTION
### What does/resolve this PR? <!-- fr: Que modifie/apporte cette PR? -->
General ergonomy. This adds autocomplete when not typing full city name and clicking directly on next field.
When city field looses focus it tries to autocomplete the Name, latitude and longitude. This limits the blank page results. Solves #130 and hopefully #116.

EDIT: this PR also resolves #194 !! The city menu reopens when focused.

And you should test it at:
https://covoli-dev-pr214.scalingo.io/

- Test of https://github.com/covoiturage-libre/covoiturage-libre/issues/116
https://covoli-dev-pr214.scalingo.io/recherche?utf8=%E2%9C%93&search%5Bfrom_city%5D=xxx&search%5Bfrom_lon%5D=&search%5Bfrom_lat%5D=&search%5Bto_city%5D=yyy&search%5Bto_lon%5D=&search%5Bto_lat%5D=&search%5Bdate%5D=30%2F12%2F2016&commit=Rechercher