### PR TITLE
Fixed validation of emails with trailling spaces

### DIFF
--- a/app/models/trip.rb
+++ b/app/models/trip.rb
@@ -25,6 +25,14 @@ class Trip < ApplicationRecord
   validates_acceptance_of :terms_of_service
   validates :email, email: true
   validates_with PricesValidator
+  # strip whitespaces before validation and save
+  before_validation :strip_whitespace
+  def strip_whitespace
+    self.email = self.email.strip unless self.email.nil?
+    self.name = self.name.strip unless self.name.nil?
+    self.phone = self.phone.strip unless self.phone.nil?
+    self.description = self.description.strip unless self.description.nil?
+  end
 
   after_create :send_confirmation_email
   after_save :set_last_point_price

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,6 +1,6 @@
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless value.strip =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
       record.errors[attribute] << (options[:message] || "n'est pas un email valide")
     end
   end

--- a/app/validators/email_validator.rb
+++ b/app/validators/email_validator.rb
@@ -1,6 +1,6 @@
 class EmailValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    unless value.strip =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
+    unless value =~ /\A([^@\s]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})\z/i
       record.errors[attribute] << (options[:message] || "n'est pas un email valide")
     end
   end


### PR DESCRIPTION
### What does/resolve this PR? <!-- fr: Que modifie/apporte cette PR? -->
Strip whitespaces before email validation.
Resolve #207 

Edit: Now the stripping is for email, name, description, and phone fields too.