### PR TITLE
Itinerary on map should be static now

### DIFF
--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -108,8 +108,7 @@
     }).addTo(myMap);
 
     var initialTripPoints = #{raw @trip.points.sort { |x, y| x.rank <=> y.rank }.map { |point| [point.lat.to_f, point.lon.to_f]}};
-    window.myTripDrawing = new TripDrawing().init(myRouting, initialTripPoints);
-    window.myRouting = myRouting;
+    var myTripDrawing = new TripDrawing().init(myRouting, initialTripPoints);
 
     // Sortabe steps
 

--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -95,9 +95,16 @@
     }).addTo(myMap);
 
     var myRouting = L.Routing.control({
-      waypoints: [],
+      plan: L.Routing.plan([], {
+        draggableWaypoints: false, // disable live edit on map
+        addWaypoints: false,
+      }),
       routeWhileDragging: true,
-      show: false // setting show to false hides the directions text block
+      show: false, // setting show to false hides the directions text block
+      // disable live edit on map
+      lineOptions : {
+        addWaypoints: false
+      }
     }).addTo(myMap);
 
     var initialTripPoints = #{raw @trip.points.sort { |x, y| x.rank <=> y.rank }.map { |point| [point.lat.to_f, point.lon.to_f]}};
@@ -105,10 +112,9 @@
     window.myRouting = myRouting;
 
     // Sortabe steps
-    
+
     $( '#steps' ).sortable({
       handle: '.handle',
       placeholder: 'step-placeholder'
     });
-    
     $( '#steps' ).disableSelection();

--- a/app/views/trips/_form.html.haml
+++ b/app/views/trips/_form.html.haml
@@ -108,7 +108,8 @@
     }).addTo(myMap);
 
     var initialTripPoints = #{raw @trip.points.sort { |x, y| x.rank <=> y.rank }.map { |point| [point.lat.to_f, point.lon.to_f]}};
-    var myTripDrawing = new TripDrawing().init(myRouting, initialTripPoints);
+    var myTripDrawing = (new TripDrawing());
+    myTripDrawing.init(myRouting, initialTripPoints);
 
     // Sortabe steps
 

--- a/app/views/trips/show.html.haml
+++ b/app/views/trips/show.html.haml
@@ -118,8 +118,15 @@
       }).addTo(map);
 
       L.Routing.control({
-        waypoints: tripPoints,
+        plan: L.Routing.plan(tripPoints, {
+          draggableWaypoints: false, // disable live edit on map
+          addWaypoints: false,
+        }),
         routeWhileDragging: true,
-        show: false // setting show to false hides the directions text block
+        show: false, // setting show to false hides the directions text block
+        // disable live edit on map
+        lineOptions : {
+          addWaypoints: false
+        }
       }).addTo(map);
     });


### PR DESCRIPTION
### What does/resolve this PR? <!-- fr: Que modifie/apporte cette PR? -->
Disable leaflet routing interactive editing. Now the map shows the content of the form and is not editable anymore (no moving/adding waypoints).

Edit: you can test it at:
https://covoli-dev-pr218.scalingo.io/trajets/nouveau