### PR TITLE
hide slaask hotline on small screen

### DIFF
--- a/app/assets/stylesheets/_slaask.scss
+++ b/app/assets/stylesheets/_slaask.scss
@@ -1,0 +1,6 @@
+#slaask-button {
+  @media screen and (max-width: 500px) {
+    display: none;
+  }
+}
+

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -30,6 +30,7 @@
 @import "link";
 @import "stickers-carousel";
 @import "steps";
+@import "_slaask";
 
 #route-wrapper {
   #route {


### PR DESCRIPTION
<!--The preferred language for communication is English  -->
<!-- fr: Les PR en francais sont également les bienvenues. Etant donné que nous espérons développer notre communauté au delà des pays francophones, nous vous invitons cependant à écrire ici en anglais si vous le pouvez, merci ;) -->

### What does/resolve this PR? <!-- fr: Que modifie/apporte cette PR? -->
Resolve #178.
Slaask was destroying our UI on some small screens by appearing in front without closing option.
We do not control the slaask freemium widget.
As we have already many users on the hotline and as its a lot of work, I chose to reduce slaask visibility. Namely, by hiding it on small screens.

No cloud testing as its a simple hack.