### PR TITLE
Patch nokogiri gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,7 +181,7 @@ GEM
     mysql2 (0.4.10)
     netrc (0.11.0)
     nio4r (2.1.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     oauth2 (1.4.0)
       faraday (>= 0.8, < 0.13)


### PR DESCRIPTION
<!--The preferred language for communication is English  -->
<!-- fr: Les PR en francais sont également les bienvenues. Etant donné que nous espérons développer notre communauté au delà des pays francophones, nous vous invitons cependant à écrire ici en anglais si vous le pouvez, merci ;) -->

### What does/resolve this PR? <!-- fr: Que modifie/apporte cette PR? -->

Update `nokogiri` gem with security patch.

CVE-2017-15412 - DENIAL OF SERVICE
libxml2 incorrectly handles certain files. An attacker can use this issue with specially constructed XML data to cause libxml2 to consume resources, leading to a denial of service.

Affected versions: Prior to 1.8.2
Fixed versions: 1.8.2
Identifier: CVE-2017-15412
Solution: Upgrade to latest version.
Sources: https://github.com/sparklemotion/nokogiri/issues/1714 
https://people.canonical.com/~ubuntu-security/cve/2017/CVE-2017-15412.html 
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15412 

### How to deploy this PR by yourself to test it? <!-- fr: Comment déployer cette PR sur votre installation pour la tester? -->


### Issues resolved by this PR (optional) <!-- fr: Numéro des issues résolues par cette PR -->


### Screenshots of the result (optional) <!-- fr: Captures d'écran du résultat, pour comparaison -->
